### PR TITLE
fix: updating PHP version in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,9 @@
-FROM php:8.1.5-fpm-alpine3.15
+FROM php:8.2-fpm-alpine3.18
 
 WORKDIR /var/www/html
 
 #install GD
-RUN apk add --no-cache freetype libpng libjpeg-turbo   \
+RUN apk add --no-cache linux-headers freetype libpng libjpeg-turbo   \
   && apk add --virtual build-deps freetype-dev libpng-dev libjpeg-turbo-dev \
   && docker-php-ext-configure gd  --with-freetype=/usr/include/  --with-jpeg=/usr/include/ \
   && nproc=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) \


### PR DESCRIPTION
As Roadmap now depends on PHP >= 8.2 the PHP image used in the Dockerfile needs to be updated.

As part of this change the linux-headers package also needs to be installed to build PHP extensions.