### PR TITLE
Livewire docs recommend adding to post-autoload-dump

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,8 @@
     "scripts": {
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
-            "@php artisan package:discover --ansi"
+            "@php artisan package:discover --ansi",
+            "@php artisan vendor:publish --force --tag=livewire:assets --ansi"
         ],
         "post-update-cmd": [
             "@php artisan vendor:publish --tag=laravel-assets --ansi --force",


### PR DESCRIPTION
Per the Livewire docs, this is recommended.

> # Publishing Frontend Assets
> If you prefer the JavaScript assets to be served by your web server not through Laravel, use the livewire:publish command:
> ```
> php artisan livewire:publish --assets
> ```
> To keep the assets up-to-date and avoid issues in future updates, we highly recommend adding the command to the post-autoload-dump scripts in your composer.json file:
> ```
> {
>     "scripts": {
>         "post-autoload-dump": [
>             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
>             "@php artisan package:discover --ansi",
>             "@php artisan vendor:publish --force --tag=livewire:assets --ansi"
>         ]
>     }
> }
> ```

See: https://laravel-livewire.com/docs/2.x/installation#publish-assets