### PR TITLE
Convert Install and Upgrade commands to Laravel Prompts

### DIFF
--- a/app/Console/Commands/Upgrade.php
+++ b/app/Console/Commands/Upgrade.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use App\Services\SystemChecker;
 use Illuminate\Console\Command;
 use App\Console\Commands\Concerns\CanShowAnIntro;
+use function Laravel\Prompts\info;
 
 class Upgrade extends Command
 {
@@ -28,42 +29,42 @@ class Upgrade extends Command
         $this->publishAssets();
         $this->line(' ');
 
-        $this->info('Upgrading done!');
+        info('Upgrading done!');
     }
 
     protected function flushVersionData(): void
     {
-        $this->info('Clearing version data cache..');
+        info('Clearing version data cache..');
 
         (new SystemChecker)->flushVersionData();
 
-        $this->info('Version data cache has been cleared.');
+        info('Version data cache has been cleared.');
     }
 
     protected function migrateMigrations(): void
     {
-        $this->info('Running migrations..');
+        info('Running migrations..');
 
         $this->call('migrate', ['--force' => true]);
     }
 
     protected function cacheRoutes(): void
     {
-        $this->info('Caching routes..');
+        info('Caching routes..');
 
         $this->call('route:cache');
     }
 
     protected function cacheViews(): void
     {
-        $this->info('Caching views..');
+        info('Caching views..');
 
         $this->call('view:cache');
     }
 
     protected function publishAssets(): void
     {
-        $this->info('Publishing assets..');
+        info('Publishing assets..');
 
         $this->call('filament:assets');
     }

--- a/tests/Feature/Console/InstallCommandTest.php
+++ b/tests/Feature/Console/InstallCommandTest.php
@@ -9,8 +9,8 @@ use function Pest\Laravel\assertDatabaseCount;
 test('install command works', function () {
     $command = artisan('roadmap:install')
         ->expectsOutput('Roadmap Installation')
-        ->expectsConfirmation('Do you want to run the migrations to set up everything fresh? (php artisan migrate:fresh)')
-        ->expectsOutput('Let\'s create a user.')
+        ->expectsConfirmation('Do you want to run the migrations to set up everything fresh?')
+        ->expectsOutputToContain('Let\'s create a user.')
         ->expectsQuestion('Name', 'John Doe')
         ->expectsQuestion('Email address', 'johndoe@ploi.io')
         ->expectsQuestion('Password', 'ploiisawesome');

--- a/tests/Feature/Console/UpgradeCommandTest.php
+++ b/tests/Feature/Console/UpgradeCommandTest.php
@@ -5,11 +5,11 @@ use function Pest\Laravel\artisan;
 test('upgrade command works', function () {
     artisan('roadmap:upgrade')
         ->expectsOutput('Roadmap Upgrade')
-        ->expectsOutput('Clearing version data cache..')
-        ->expectsOutput('Version data cache has been cleared.')
-        ->expectsOutput('Caching routes..')
-        ->expectsOutput('Caching views..')
-        ->expectsOutput('Running migrations..')
-        ->expectsOutput('Upgrading done!')
+        ->expectsOutputToContain('Clearing version data cache..')
+        ->expectsOutputToContain('Version data cache has been cleared.')
+        ->expectsOutputToContain('Caching routes..')
+        ->expectsOutputToContain('Caching views..')
+        ->expectsOutputToContain('Running migrations..')
+        ->expectsOutputToContain('Upgrading done!')
         ->run();
-});
+})->only();


### PR DESCRIPTION
- Convert install command inputs to [Laravel Prompts](https://laravel.com/docs/11.x/prompts)
- Convert install and upgrade outputs to [Laravel Prompt Info Messages](https://laravel.com/docs/11.x/prompts#informational-messages)
- Updated tests