### PR TITLE
Add missing `cd roadmap` command to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ First set up a database, and remember the credentials.
 
 ```
 git clone https://github.com/ploi/roadmap.git
+cd roadmap
 composer install --no-interaction --prefer-dist --optimize-autoloader --no-dev
 php -r "file_exists('.env') || copy('.env.example', '.env');"
 php artisan key:generate


### PR DESCRIPTION
This PR adds a critical step that was missing from the installation instructions in the README.md. After cloning the repository, users need to change into the project directory before running subsequent commands.

## Changes

- Added `cd roadmap` command after the git clone step in the installation instructions

## Why this matters

Without this step, users would try to run `composer install` and other commands from outside the project directory, leading to errors and a frustrating installation experience. This small addition makes the installation process smoother and more intuitive, especially for developers who might be new to the project.

Kudos to the Ploi team for maintaining this excellent open source roadmap project! Your work helps teams stay organized and focused on what matters.