### PR TITLE
Enable collapsed state for boards and add live title updates

### DIFF
--- a/app/Filament/Resources/ProjectResource.php
+++ b/app/Filament/Resources/ProjectResource.php
@@ -117,11 +117,12 @@ class ProjectResource extends Resource
                            Repeater::make('boards')
                                    ->label(trans('resources.board.label-plural'))
                                    ->collapsible()
-                               //->collapsed() // We can enable this when Filament has a way to set header titles
+                                   ->collapsed()
                                    ->relationship('boards')
                                    ->orderColumn('sort_order')
                                    ->default(app(GeneralSettings::class)->default_boards)
                                    ->columnSpan(2)
+                                   ->itemLabel(fn ($state) => $state['title'] ?? '')
                                    ->schema([
                                        Grid::make()->schema([
                                            Toggle::make('visible')
@@ -145,7 +146,8 @@ class ProjectResource extends Resource
                                        Grid::make()->schema([
                                            TextInput::make('title')
                                                     ->label(trans('resources.board.title'))
-                                                    ->required(),
+                                                    ->required()
+                                                    ->live(),
 
                                            Select::make('sort_items_by')
                                                  ->label(trans('resources.board.sort-items-by'))


### PR DESCRIPTION
The boards Repeater now utilizes the collapsed state for better UI organization. Additionally, live updates are enabled for the title field, improving real-time feedback during input.