### PR TITLE
fix: add auth middleware to item edit route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -34,7 +34,7 @@ Route::get('changelog/{changelog}', [ChangelogController::class, 'show'])->name(
 
 Route::get('projects/{project}', [ProjectController::class, 'show'])->name('projects.show');
 Route::get('items/{item}', [ItemController::class, 'show'])->name('items.show');
-Route::get('items/{item}/edit', [ItemController::class, 'edit'])->name('items.edit');
+Route::get('items/{item}/edit', [ItemController::class, 'edit'])->middleware('authed')->name('items.edit');
 Route::get('projects/{project}/items/{item}', [ItemController::class, 'show'])->name('projects.items.show');
 Route::get('projects/{project}/items/{item}/ai', [ItemController::class, 'ai'])->name('projects.items.ai');
 Route::post('projects/{project}/items/{item}/vote', [ItemController::class, 'vote'])->middleware('authed')->name('projects.items.vote');


### PR DESCRIPTION
The items/{item}/edit route was missing the authed middleware, causing a "Call to a member function items() on null" error when unauthenticated users accessed the URL.