### PR TITLE
Update PHP version in Dockerfile to 8.4

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm-alpine3.18
+FROM php:8.4-fpm-alpine3.21
 
 WORKDIR /var/www/html
 


### PR DESCRIPTION
  ## What
  Updates `docker/Dockerfile` base image from `php:8.2-fpm-alpine3.18` to `php:8.4-fpm-alpine3.21`.

  ## Why
  The README "Requirements" section states **PHP >= 8.4**, but the Docker image
  currently ships PHP 8.2, so Docker users don't get the documented environment.

  | Source | PHP version |
  |---|---|
  | README → Requirements | >= 8.4 |
  | docker/Dockerfile (before) | 8.2 |
  | docker/Dockerfile (after) | 8.4 |
  
  ## Testing
  - `docker compose -f docker/docker-compose.yml build roadmap` succeeds
  - Container boots and serves the app