### PR TITLE
Add Lettermint mail transport

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "laravel/socialite": "^5.6.1",
         "laravel/tinker": "^2.8.0",
         "laravel/ui": "^4.2.0",
+        "lettermint/lettermint-laravel": "^2.2",
         "sentry/sentry-laravel": "^4.0",
         "spatie/color": "^1.5",
         "spatie/laravel-activitylog": "^4.7.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b62681529bed9e4fc2df2161e75c651",
+    "content-hash": "71d1d496b494135bed25a03d3ac2f726",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -4922,6 +4922,139 @@
                 }
             ],
             "time": "2026-03-08T20:05:35+00:00"
+        },
+        {
+            "name": "lettermint/lettermint-laravel",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lettermint/lettermint-laravel.git",
+                "reference": "ffc42058df3c81d09897e1488f41e61a4abd0dec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lettermint/lettermint-laravel/zipball/ffc42058df3c81d09897e1488f41e61a4abd0dec",
+                "reference": "ffc42058df3c81d09897e1488f41e61a4abd0dec",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^10.0 | ^11.0 | ^12.0 | ^13.0",
+                "lettermint/lettermint-php": "^2.1",
+                "php": "^8.2",
+                "spatie/laravel-package-tools": "^1.16"
+            },
+            "require-dev": {
+                "larastan/larastan": "^2.9||^3.0",
+                "laravel/pint": "^1.14",
+                "nunomaduro/collision": "^8.1.1||^7.10.0||^9.0",
+                "orchestra/testbench": "^11.0||^10.0||^9.0||^8.22.0",
+                "pestphp/pest": "^2.28||^3.0||^4.0",
+                "pestphp/pest-plugin-arch": "^2.5||^3.0||^4.0",
+                "pestphp/pest-plugin-laravel": "^2.2||^3.0||^4.0",
+                "phpstan/extension-installer": "^1.3||^2.0",
+                "phpstan/phpstan-deprecation-rules": "^1.1||^2.0",
+                "phpstan/phpstan-phpunit": "^1.3||^2.0",
+                "spatie/laravel-ray": "^1.35"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Lettermint": "Lettermint\\Laravel\\Facades\\Lettermint"
+                    },
+                    "providers": [
+                        "Lettermint\\Laravel\\LettermintServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Lettermint\\Laravel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bjarn Bronsveld",
+                    "email": "bjarn@lettermint.co",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Official Lettermint driver for Laravel",
+            "homepage": "https://github.com/lettermint/lettermint-laravel",
+            "keywords": [
+                "laravel",
+                "lettermint",
+                "lettermint-laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/lettermint/lettermint-laravel/issues",
+                "source": "https://github.com/lettermint/lettermint-laravel/tree/2.2.1"
+            },
+            "time": "2026-08-25T20:41:29+00:00"
+        },
+        {
+            "name": "lettermint/lettermint-php",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lettermint/lettermint-php.git",
+                "reference": "cf597bda932aba303f04e956189bef53286cea4a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lettermint/lettermint-php/zipball/cf597bda932aba303f04e956189bef53286cea4a",
+                "reference": "cf597bda932aba303f04e956189bef53286cea4a",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^7.9",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "larastan/larastan": "^2.9||^3.0",
+                "laravel/pint": "^1.14",
+                "nunomaduro/collision": "^8.1.1||^7.10.0",
+                "orchestra/testbench": "^10.0.0||^9.0.0||^8.22.0",
+                "pestphp/pest": "^3.0",
+                "pestphp/pest-plugin-arch": "^3.0",
+                "pestphp/pest-plugin-laravel": "^3.0",
+                "phpstan/extension-installer": "^1.3||^2.0",
+                "phpstan/phpstan-deprecation-rules": "^1.1||^2.0",
+                "phpstan/phpstan-phpunit": "^1.3||^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Lettermint\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bjarn Bronsveld",
+                    "email": "bjarn@lettermint.co",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Official Lettermint PHP SDK.",
+            "homepage": "https://github.com/lettermint/lettermint-php",
+            "keywords": [
+                "lettermint",
+                "lettermint-php",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/lettermint/lettermint-php/issues",
+                "source": "https://github.com/lettermint/lettermint-php/tree/2.6.0"
+            },
+            "time": "2026-09-05T11:16:44+00:00"
         },
         {
             "name": "livewire/livewire",

--- a/config/mail.php
+++ b/config/mail.php
@@ -63,6 +63,10 @@ return [
             ]
         ],
 
+        'lettermint' => [
+            'transport' => 'lettermint',
+        ],
+
         'sendmail' => [
             'transport' => 'sendmail',
             'path' => env('MAIL_SENDMAIL_PATH', '/usr/sbin/sendmail -bs -i'),

--- a/config/services.php
+++ b/config/services.php
@@ -25,6 +25,10 @@ return [
         'token' => env('POSTMARK_TOKEN'),
     ],
 
+    'lettermint' => [
+        'token' => env('LETTERMINT_PROJECT_TOKEN', env('LETTERMINT_TOKEN')),
+    ],
+
     'ses' => [
         'key' => env('AWS_ACCESS_KEY_ID'),
         'secret' => env('AWS_SECRET_ACCESS_KEY'),

--- a/tests/Feature/MailConfigurationTest.php
+++ b/tests/Feature/MailConfigurationTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use Illuminate\Support\Facades\Mail;
+use Lettermint\Laravel\Transport\LettermintTransportFactory;
+
+test('lettermint mailer is defined and resolves', function () {
+    config(['services.lettermint.token' => 'test-token']);
+
+    // Mail is faked globally in Pest.php, so resolve through the real manager.
+    $transport = Mail::getFacadeRoot()->manager->mailer('lettermint')->getSymfonyTransport();
+
+    expect($transport)->toBeInstanceOf(LettermintTransportFactory::class);
+});


### PR DESCRIPTION
Adds support for [Lettermint](https://lettermint.co) as a mail provider via the official `lettermint/lettermint-laravel` package.

## Why

Setting `MAIL_MAILER=lettermint` currently fails with `Mailer [lettermint] is not defined.`, because `MAIL_MAILER` must name an entry in `config/mail.php`. Any code path that sends mail (e.g. resending the email verification notification) then returns a 500.

## Changes

- Require `lettermint/lettermint-laravel` (`^2.2`), which registers the `lettermint` transport
- Add a `lettermint` mailer to `config/mail.php`
- Add a `lettermint` entry to `config/services.php`, reading `LETTERMINT_PROJECT_TOKEN` (falls back to `LETTERMINT_TOKEN`)
- Add a test asserting the `lettermint` mailer resolves to the Lettermint transport

Existing setups are unaffected; the default mailer is unchanged.

## Usage

```env
MAIL_MAILER=lettermint
LETTERMINT_PROJECT_TOKEN=your-project-token
```