### PR TITLE
Fix translation keys that do not resolve

### DIFF
--- a/app/Filament/Resources/Boards/BoardResource.php
+++ b/app/Filament/Resources/Boards/BoardResource.php
@@ -82,7 +82,7 @@ class BoardResource extends Resource
                           ->label(trans('resources.board.project')),
 
                 TextColumn::make('created_at')
-                    ->label(trans('resources.user.created-at'))
+                    ->label(trans('resources.created-at'))
                     ->dateTime()
                     ->sortable(),
                 ]

--- a/app/Filament/Resources/Items/ItemResource.php
+++ b/app/Filament/Resources/Items/ItemResource.php
@@ -138,7 +138,7 @@ class ItemResource extends Resource
                                                     ->icon('heroicon-s-plus')
                                                     ->tooltip(trans('resources.item.github.create'))
                                                     ->modalHeading(trans('resources.item.github.create-new'))
-                                                    ->modalSubmitActionLabel(trans('resources.item.github-issue-create'))
+                                                    ->modalSubmitActionLabel(trans('resources.item.github.create'))
                                                     ->schema(
                                                         [
                                                                                     Grid::make()

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -11,7 +11,7 @@
 
                 @if (session('resent'))
                     <div class="alert-success" role="alert">
-                        {{ trans('auth.verify-new-success.') }}
+                        {{ trans('auth.verify-new-success') }}
                     </div>
                 @endif
 

--- a/resources/views/auth/verify.blade.php
+++ b/resources/views/auth/verify.blade.php
@@ -10,7 +10,7 @@
                 <div class="card-body">
                     @if (session('resent'))
                         <div class="alert alert-success" role="alert">
-                            {{ trans('auth.verify-new-success.') }}
+                            {{ trans('auth.verify-new-success') }}
                         </div>
                     @endif
 

--- a/tests/Feature/TranslationKeysTest.php
+++ b/tests/Feature/TranslationKeysTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Lang;
+use Symfony\Component\Finder\Finder;
+
+test('all translation keys used in the codebase exist', function () {
+    $groups = collect(glob(lang_path('en/*.php')))
+        ->map(fn (string $file) => basename($file, '.php'))
+        ->all();
+
+    $files = Finder::create()
+        ->files()
+        ->name('*.php')
+        ->in([app_path(), resource_path('views')]);
+
+    $missing = [];
+
+    foreach ($files as $file) {
+        // Only match keys passed as a complete string literal, so concatenated keys are skipped.
+        preg_match_all(
+            '/(?:\b__|\btrans|\btrans_choice|@lang)\(\s*([\'"])([a-z0-9_-]+\.[^\'"$]+)\1\s*[,)]/i',
+            $file->getContents(),
+            $matches
+        );
+
+        foreach ($matches[2] as $key) {
+            if (in_array(strtok($key, '.'), $groups, true) && ! Lang::has($key, 'en', false)) {
+                $missing[] = $file->getRelativePathname().': '.$key;
+            }
+        }
+    }
+
+    expect($missing)->toBeEmpty();
+});


### PR DESCRIPTION
A few `trans()` calls reference keys that don't exist, so the raw key is shown to users instead of the translated text.

## Fixes

| Where | Was | Now |
| --- | --- | --- |
| `auth/verify-email.blade.php`, `auth/verify.blade.php` | `auth.verify-new-success.` (trailing period inside the key) | `auth.verify-new-success` |
| `BoardResource` created at column | `resources.user.created-at` | `resources.created-at` (as used by every other resource) |
| `ItemResource` GitHub issue modal submit button | `resources.item.github-issue-create` | `resources.item.github.create` |

The first one is the most visible: after requesting a new verification email, the success banner reads `auth.verify-new-success.` instead of "A fresh verification link has been sent to your email address."

## Regression test

Adds `tests/Feature/TranslationKeysTest.php`, which scans `app/` and `resources/views` for translation keys passed as a string literal to `__()`, `trans()`, `trans_choice()` or `@lang`, and asserts each one exists in the English translations. Dynamically built keys (e.g. `'general.' . $type`) are skipped. The test fails on `main` and passes with these fixes.